### PR TITLE
[Fix] allow moving files across drives

### DIFF
--- a/cmdHandlers.go
+++ b/cmdHandlers.go
@@ -313,7 +313,7 @@ func saveSong(filePath string, force bool) error {
 	wavFile := fileName + ".wav"
 	sourcePath := filepath.Join(filepath.Dir(filePath), wavFile)
 	newFilePath := filepath.Join(SONGS_DIR, wavFile)
-	err = os.Rename(sourcePath, newFilePath)
+	err = utils.MoveFile(sourcePath, newFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to rename temporary file to output file: %v", err)
 	}

--- a/socketHandlers.go
+++ b/socketHandlers.go
@@ -10,6 +10,7 @@ import (
 	"song-recognition/shazam"
 	"song-recognition/spotify"
 	"song-recognition/utils"
+	"song-recognition/wav"
 	"strings"
 
 	socketio "github.com/googollee/go-socket.io"
@@ -186,7 +187,7 @@ func handleNewRecording(socket socketio.Conn, recordData string) {
 		return
 	}
 
-	samples, err := utils.ProcessRecording(&recData, true)
+	samples, err := wav.ProcessRecording(&recData, true)
 	if err != nil {
 		err := xerrors.New(err)
 		logger.ErrorContext(ctx, "Failed to process recording.", slog.Any("error", err))

--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -1,18 +1,10 @@
 package utils
 
 import (
-	"context"
-	"encoding/base64"
 	"encoding/binary"
 	"fmt"
-	"log/slog"
+	"io"
 	"os"
-	"song-recognition/models"
-	"song-recognition/wav"
-	"strings"
-	"time"
-
-	"github.com/mdobak/go-xerrors"
 )
 
 func DeleteFile(filePath string) error {
@@ -29,6 +21,36 @@ func CreateFolder(folderPath string) error {
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+func MoveFile(sourcePath string, destinationPath string) error {
+	srcFile, err := os.Open(sourcePath)
+	if err != nil {
+		return err
+	}
+
+	destFile, err := os.Create(destinationPath)
+	if err != nil {
+		return err
+	}
+	defer destFile.Close()
+
+	_, err = io.Copy(destFile, srcFile)
+	if err != nil {
+		return err
+	}
+
+	err = srcFile.Close()
+	if err != nil {
+		return err
+	}
+
+	err = os.Remove(sourcePath)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -71,53 +93,4 @@ func FloatsToBytes(data []float64, bitsPerSample int) ([]byte, error) {
 	}
 
 	return byteData, nil
-}
-
-func ProcessRecording(recData *models.RecordData, saveRecording bool) ([]float64, error) {
-	decodedAudioData, err := base64.StdEncoding.DecodeString(recData.Audio)
-	if err != nil {
-		return nil, err
-	}
-
-	now := time.Now()
-	fileName := fmt.Sprintf("%04d_%02d_%02d_%02d_%02d_%02d.wav",
-		now.Second(), now.Minute(), now.Hour(),
-		now.Day(), now.Month(), now.Year(),
-	)
-	filePath := "tmp/" + fileName
-
-	err = wav.WriteWavFile(filePath, decodedAudioData, recData.SampleRate, recData.Channels, recData.SampleSize)
-	if err != nil {
-		return nil, err
-	}
-
-	reformatedWavFile, err := wav.ReformatWAV(filePath, 1)
-	if err != nil {
-		return nil, err
-	}
-
-	wavInfo, _ := wav.ReadWavInfo(reformatedWavFile)
-	samples, _ := wav.WavBytesToSamples(wavInfo.Data)
-
-	if saveRecording {
-		logger := GetLogger()
-		ctx := context.Background()
-
-		err := CreateFolder("recordings")
-		if err != nil {
-			err := xerrors.New(err)
-			logger.ErrorContext(ctx, "Failed create folder.", slog.Any("error", err))
-		}
-
-		newFilePath := strings.Replace(reformatedWavFile, "tmp/", "recordings/", 1)
-		err = os.Rename(reformatedWavFile, newFilePath)
-		if err != nil {
-			logger.ErrorContext(ctx, "Failed to move file.", slog.Any("error", err))
-		}
-	}
-
-	DeleteFile(fileName)
-	DeleteFile(reformatedWavFile)
-
-	return samples, nil
 }

--- a/wav/convert.go
+++ b/wav/convert.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"song-recognition/utils"
 	"strings"
 )
 
@@ -43,7 +44,7 @@ func ConvertToWAV(inputFilePath string, channels int) (wavFilePath string, err e
 	}
 
 	// Rename the temporary file to the output file
-	err = os.Rename(tmpFile, outputFile)
+	err = utils.MoveFile(tmpFile, outputFile)
 	if err != nil {
 		return "", fmt.Errorf("failed to rename temporary file to output file: %v", err)
 	}

--- a/wav/wav.go
+++ b/wav/wav.go
@@ -2,13 +2,22 @@ package wav
 
 import (
 	"bytes"
+	"context"
+	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log/slog"
 	"os"
 	"os/exec"
+	"song-recognition/models"
+	"song-recognition/utils"
+	"strings"
+	"time"
+
+	"github.com/mdobak/go-xerrors"
 )
 
 // WavHeader defines the structure of a WAV header
@@ -199,4 +208,53 @@ func GetMetadata(filePath string) (FFmpegMetadata, error) {
 	}
 
 	return metadata, nil
+}
+
+func ProcessRecording(recData *models.RecordData, saveRecording bool) ([]float64, error) {
+	decodedAudioData, err := base64.StdEncoding.DecodeString(recData.Audio)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+	fileName := fmt.Sprintf("%04d_%02d_%02d_%02d_%02d_%02d.wav",
+		now.Second(), now.Minute(), now.Hour(),
+		now.Day(), now.Month(), now.Year(),
+	)
+	filePath := "tmp/" + fileName
+
+	err = WriteWavFile(filePath, decodedAudioData, recData.SampleRate, recData.Channels, recData.SampleSize)
+	if err != nil {
+		return nil, err
+	}
+
+	reformatedWavFile, err := ReformatWAV(filePath, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	wavInfo, _ := ReadWavInfo(reformatedWavFile)
+	samples, _ := WavBytesToSamples(wavInfo.Data)
+
+	if saveRecording {
+		logger := utils.GetLogger()
+		ctx := context.Background()
+
+		err := utils.CreateFolder("recordings")
+		if err != nil {
+			err := xerrors.New(err)
+			logger.ErrorContext(ctx, "Failed create folder.", slog.Any("error", err))
+		}
+
+		newFilePath := strings.Replace(reformatedWavFile, "tmp/", "recordings/", 1)
+		err = os.Rename(reformatedWavFile, newFilePath)
+		if err != nil {
+			logger.ErrorContext(ctx, "Failed to move file.", slog.Any("error", err))
+		}
+	}
+
+	utils.DeleteFile(fileName)
+	utils.DeleteFile(reformatedWavFile)
+
+	return samples, nil
 }


### PR DESCRIPTION
This PR manually implements renaming files by creating a new file with the new name and coping over the contents from the old file to the new one. It then removes the old file, effectively renaming the original file. This method does not have the same limitation of `os.Rename` which can't move/rename files on separate drives.

*some existing methods were relocated to avoid cycle dependencies*


Closes #18 