### PR TITLE
[Fix] convert tags keys to lowercase

### DIFF
--- a/cmdHandlers.go
+++ b/cmdHandlers.go
@@ -296,9 +296,12 @@ func saveSong(filePath string, force bool) error {
 		return fmt.Errorf("failed to get YouTube ID for song: %v", err)
 	}
 
+	fileName := strings.TrimSuffix(filepath.Base(filePath), filepath.Ext(filePath))
 	if track.Title == "" {
-		return fmt.Errorf("no title found in metadata")
+		// If title is empty, use the file name
+		track.Title = fileName
 	}
+
 	if track.Artist == "" {
 		return fmt.Errorf("no artist found in metadata")
 	}
@@ -309,7 +312,6 @@ func saveSong(filePath string, force bool) error {
 	}
 
 	// Move song in wav format to songs directory
-	fileName := strings.TrimSuffix(filepath.Base(filePath), filepath.Ext(filePath))
 	wavFile := fileName + ".wav"
 	sourcePath := filepath.Join(filepath.Dir(filePath), wavFile)
 	newFilePath := filepath.Join(SONGS_DIR, wavFile)

--- a/spotify/downloader.go
+++ b/spotify/downloader.go
@@ -307,7 +307,7 @@ func ProcessAndSaveSong(songFilePath, songTitle, songArtist, ytID string) error 
 	err = dbclient.StoreFingerprints(fingerprints)
 	if err != nil {
 		dbclient.DeleteSongByID(songID)
-		return fmt.Errorf("error to storing fingerpring: %v", err)
+		return fmt.Errorf("error to storing fingerprint: %v", err)
 	}
 
 	fmt.Printf("Fingerprint for %v by %v saved in DB successfully\n", songTitle, songArtist)

--- a/wav/wav.go
+++ b/wav/wav.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 // WavHeader defines the structure of a WAV header
@@ -196,6 +197,14 @@ func GetMetadata(filePath string) (FFmpegMetadata, error) {
 	err = json.Unmarshal(out.Bytes(), &metadata)
 	if err != nil {
 		return metadata, err
+	}
+
+	// convert all keys of the Tags map to lowercase
+	for k, v := range metadata.Format.Tags {
+		metadata.Format.Tags[strings.ToLower(k)] = v
+	}
+	for k, v := range metadata.Streams[0].Tags {
+		metadata.Streams[0].Tags[strings.ToLower(k)] = v
 	}
 
 	return metadata, nil


### PR DESCRIPTION
This PR converts all the tag keys captured from ffprobe to lowercase to allow for metadata selection in a case insensitive manner. It also will fallback on using the filename as the track title instead of failing completely. 

Closes #22, #17