### PR TITLE
fix(docker): added Spotify env variables and Ffmpeg binary to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ WORKDIR /home/seek-tune
 
 COPY server/go.mod server/go.sum ./
 RUN go mod download
+RUN apt-get update && apt-get install -y ffmpeg
 
 COPY server/ ./
 ENV ENV=production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.1'
+version: "3.1"
 
 volumes:
   seek-tune-db:
@@ -6,7 +6,7 @@ volumes:
 
 services:
   seek-tune:
-    image: 'seek-tune'
+    image: "seek-tune"
     restart: unless-stopped
     ports:
       - 8080:5000
@@ -20,6 +20,8 @@ services:
       DB_PORT: ${DB_PORT:-27017}
 
       REACT_APP_BACKEND_URL: ${REACT_APP_BACKEND_URL:-http://localhost:8080}
+      SPOTIFY_CLIENT_ID: ${SPOTIFY_CLIENT_ID}
+      SPOTIFY_CLIENT_SECRET: ${SPOTIFY_CLIENT_SECRET}
 
     build:
       context: .


### PR DESCRIPTION
**Fix 1**: The docker-compose.yml file has been updated to pass the Spotify client details from the local .env file into the container. 

**Fix 2**: FFMpeg binary is unavailable for docker image. Hence, the Dockerfile is now configured to install the ffmpeg binary.